### PR TITLE
Python 3 compatibility

### DIFF
--- a/cleancat/utils.py
+++ b/cleancat/utils.py
@@ -4,20 +4,20 @@ from cleancat import ValidationError
 def compare_dict_keys(data, keys, test_true=True):
     if isinstance(keys, list):
         keys = dict((key, None) for key in keys)
-    for k, v in keys.iteritems():
+    for k, v in keys.items():
         assert k in data, 'Key %r not in %r' % (k, data)
         if test_true:
             assert data.get(k), 'Key %r is None in %r' % (k, data)
         if isinstance(v, dict) or isinstance(v, list):
             compare_dict_keys(data[k], v)
-    for k, v in data.iteritems():
+    for k, v in data.items():
         if test_true:
             assert not v or k in keys, 'Key %r is unexpectedly true in %r' % (k, data)
         else:
             assert k in keys, 'Key %r is unexpected in %r' % (k, data)
 
 def compare_req_resp(req_obj, resp_obj):
-    for k,v in req_obj.iteritems():
+    for k, v in req_obj.items():
         assert k in resp_obj.keys(), 'Key %r not in response (keys are %r)' % (k, resp_obj.keys())
         assert resp_obj[k] == v, 'Value for key %r should be %r but is %r' % (k, v, resp_obj[k])
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -48,9 +48,9 @@ class FieldTestCase(ValidationTestCase):
         class RegexOptionsSchema(Schema):
             letter = Regex('^[a-z]$', re.IGNORECASE)
         class RegexMessageSchema(Schema):
-            letter = Regex('^[a-z]$', regex_message=u'Not a lowercase letter.')
+            letter = Regex('^[a-z]$', regex_message='Not a lowercase letter.')
         class OptionalRegexMessageSchema(Schema):
-            letter = Regex('^[a-z]$', regex_message=u'Not a lowercase letter.', required=False)
+            letter = Regex('^[a-z]$', regex_message='Not a lowercase letter.', required=False)
 
         self.assertValid(RegexSchema({'letter': 'a'}), {'letter': 'a'})
         self.assertInvalid(RegexSchema({'letter': 'A'}), {'field-errors': ['letter']})
@@ -66,18 +66,18 @@ class FieldTestCase(ValidationTestCase):
 
         schema = RegexMessageSchema({'letter': ''})
         self.assertInvalid(schema, {'field-errors': ['letter']})
-        self.assertEqual(schema.field_errors['letter'], u'This field is required.')
+        self.assertEqual(schema.field_errors['letter'], 'This field is required.')
 
         schema = RegexMessageSchema({'letter': 'aa'})
         self.assertInvalid(schema, {'field-errors': ['letter']})
-        self.assertEqual(schema.field_errors['letter'], u'Not a lowercase letter.')
+        self.assertEqual(schema.field_errors['letter'], 'Not a lowercase letter.')
 
         self.assertValid(OptionalRegexMessageSchema({'letter': 'a'}), {'letter': 'a'})
         self.assertValid(OptionalRegexMessageSchema({'letter': ''}), {'letter': ''})
 
         schema = OptionalRegexMessageSchema({'letter': 'aa'})
         self.assertInvalid(schema, {'field-errors': ['letter']})
-        self.assertEqual(schema.field_errors['letter'], u'Not a lowercase letter.')
+        self.assertEqual(schema.field_errors['letter'], 'Not a lowercase letter.')
 
     def test_datetime(self):
         class DateTimeSchema(Schema):
@@ -86,7 +86,7 @@ class FieldTestCase(ValidationTestCase):
         from pytz import utc
 
         self.assertValid(DateTimeSchema({'dt': '2012-10-09'}), {'dt': datetime.date(2012,10,9)})
-        self.assertValid(DateTimeSchema({'dt': '2012-10-09 13:10:04'}), {'dt': datetime.datetime(2012,10,9, 13,10,04)})
+        self.assertValid(DateTimeSchema({'dt': '2012-10-09 13:10:04'}), {'dt': datetime.datetime(2012,10,9, 13,10, 4)})
         self.assertValid(DateTimeSchema({'dt': '2013-03-27T01:24:50.137000+00:00'}), {'dt': datetime.datetime(2013,3,27, 1,24,50, 137000, tzinfo=utc)})
         self.assertInvalid(DateTimeSchema({'dt': '0000-01-01T00:00:00-08:00'}), {'field-errors': ['dt']})
         self.assertInvalid(DateTimeSchema({'dt': '2012a'}), {'field-errors': ['dt']})
@@ -108,7 +108,7 @@ class FieldTestCase(ValidationTestCase):
         self.assertValid(EmailSchema({'email': 'test@example.com'}), {'email': 'test@example.com'})
         schema = EmailSchema({'email': 'test@example'})
         self.assertInvalid(schema, {'field-errors': ['email']})
-        self.assertEqual(schema.field_errors['email'], u'Invalid email address.')
+        self.assertEqual(schema.field_errors['email'], 'Invalid email address.')
         self.assertInvalid(EmailSchema({'email': 'test.example.com'}), {'field-errors': ['email']})
         self.assertInvalid(EmailSchema({'email': None}), {'field-errors': ['email']})
         self.assertInvalid(EmailSchema({}), {'field-errors': ['email']})


### PR DESCRIPTION
Perhaps you're interested in this, perhaps not.  It is just a quick Python 2+3 compatibility commit, simply the stuff I noticed when importing it in to my default 3.3 environment.

Note that it changes many Unicode literals to simple strings, which shouldn't introduce backwards compatibility problems unless downstream users are doing lots of naïve `isinstance` tests.

This remains compatible with Python 2.6 and above, and if Python 2.5 support is desired it would only require a little reworking of the exception handling.

Thanks,

James